### PR TITLE
Upgrade surrealdb 3.1.0-beta.3 -> 3.1.2 in runtime crates

### DIFF
--- a/apps/scheduler/Cargo.lock
+++ b/apps/scheduler/Cargo.lock
@@ -4578,9 +4578,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb"
-version = "3.0.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18997a4c20c9559461846bff0dad185854c32639407904e2bb97567b4fa6a63"
+checksum = "290298f4df7c85ed50881d15ce4a49ec0d3d030e0e9e5215c0b5344afe5ef380"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4615,9 +4615,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "3.0.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470a61158ca8b4e774f8be3a8fbe1393bd33c026d9025a3db8f5ada0a06adf6a"
+checksum = "bc74bf4defa63b4b3cc9f95b4a3e716aa5b4cfc7e13871a7e7da9f634a1273db"
 dependencies = [
  "addr",
  "affinitypool",
@@ -4705,9 +4705,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-librocksdb-sys"
-version = "0.17.3+10.6.2"
+version = "0.18.2+11.0.0-3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db194f1cf601bb6f2d0f4cbf0931bc3e5a602bac41ef2e9a87eccdfb28b7fed2"
+checksum = "5db9846a21fa94751559c4a99df87f16e3698510b97d550e43383a796d251965"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -4720,9 +4720,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-protocol"
-version = "0.8.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb37698e0493bcfac3229ecb6ec6894a3ad705a3a2087b1562eeb881b3db19d4"
+checksum = "f57065763bbd36486c449132252b3aac5a5e20f5669393ded0e967e8f8289ea2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4744,9 +4744,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-rocksdb"
-version = "0.24.0-surreal.1"
+version = "0.24.0-surreal.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057727f56d48825ddbe45e4e7401cda6e99d864fbc004e7474b4689a5e72c86d"
+checksum = "36a425c4d4447c2b0ed3361e370de662e5a8f56d89f12c301db81fd45ba35731"
 dependencies = [
  "libc",
  "surrealdb-librocksdb-sys",
@@ -4754,9 +4754,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types"
-version = "3.0.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58db59440236ec593dbbb2487c4db11e4452ee636f9a1da3e3672c1cc1f42259"
+checksum = "8b24fe0d9852fdd25f4746be5ea3570f2b56273cfa4e3303fb77fa770a3e33a8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4780,9 +4780,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types-derive"
-version = "3.0.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617a808c9b3a2cd688c98027f4781c522507df73b42b1c56820ae72407eda016"
+checksum = "19d50454f56d5e0d633541054feffd0b1c907079585e7286cdc6e6c5d13ce4c9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apps/scheduler/Cargo.toml
+++ b/apps/scheduler/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "signal", "net", "io-util"] }
-surrealdb = { version = "3.1.0-beta.3", features = ["kv-rocksdb", "protocol-ws", "protocol-http"] }
+surrealdb = { version = "3.1.2", features = ["kv-rocksdb", "protocol-ws", "protocol-http"] }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/apps/ssp/Cargo.lock
+++ b/apps/ssp/Cargo.lock
@@ -4731,9 +4731,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb"
-version = "3.0.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18997a4c20c9559461846bff0dad185854c32639407904e2bb97567b4fa6a63"
+checksum = "290298f4df7c85ed50881d15ce4a49ec0d3d030e0e9e5215c0b5344afe5ef380"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4768,9 +4768,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "3.0.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470a61158ca8b4e774f8be3a8fbe1393bd33c026d9025a3db8f5ada0a06adf6a"
+checksum = "bc74bf4defa63b4b3cc9f95b4a3e716aa5b4cfc7e13871a7e7da9f634a1273db"
 dependencies = [
  "addr",
  "ahash 0.8.12",
@@ -4854,9 +4854,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-protocol"
-version = "0.8.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb37698e0493bcfac3229ecb6ec6894a3ad705a3a2087b1562eeb881b3db19d4"
+checksum = "f57065763bbd36486c449132252b3aac5a5e20f5669393ded0e967e8f8289ea2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4878,9 +4878,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types"
-version = "3.0.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58db59440236ec593dbbb2487c4db11e4452ee636f9a1da3e3672c1cc1f42259"
+checksum = "8b24fe0d9852fdd25f4746be5ea3570f2b56273cfa4e3303fb77fa770a3e33a8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4904,9 +4904,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types-derive"
-version = "3.0.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617a808c9b3a2cd688c98027f4781c522507df73b42b1c56820ae72407eda016"
+checksum = "19d50454f56d5e0d633541054feffd0b1c907079585e7286cdc6e6c5d13ce4c9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apps/ssp/Cargo.toml
+++ b/apps/ssp/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1.0"
 axum = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-surrealdb = { version = "3.1.0-beta.3", features = ["protocol-ws", "protocol-http"] }
+surrealdb = { version = "3.1.2", features = ["protocol-ws", "protocol-http"] }
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "sync", "time", "signal", "net", "io-util"] }
 ssp = { path = "../../packages/ssp" }
 job-runner = { path = "../../packages/job-runner" }

--- a/packages/job-runner/Cargo.toml
+++ b/packages/job-runner/Cargo.toml
@@ -9,6 +9,6 @@ reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
-surrealdb = { version = "3.1.0-beta.3", features = ["protocol-ws"] }
+surrealdb = { version = "3.1.2", features = ["protocol-ws"] }
 tracing = "0.1"
 anyhow = "1"


### PR DESCRIPTION
## What

Bumps the SurrealDB Rust SDK from the prerelease `3.1.0-beta.3` to stable **3.1.2** in the runtime sync-engine crates:

- `apps/ssp` (ssp-server)
- `apps/scheduler`
- `packages/job-runner`

No source changes were needed — these crates were already written against the v3 API (`surrealdb::types::RecordId/Value`, `engine::remote::ws`, `engine::local::RocksDb`, `opt::capabilities`, `.export()/.import()`). Per-crate lockfiles for `apps/ssp` and `apps/scheduler` are synced to the 3.1.2 family.

## Out of scope

`apps/cli` intentionally stays on `surrealdb-core` 2.x. Its only surrealdb use is offline SurrealQL schema parsing (`parser.rs`), and v3 made the SurrealQL AST `pub(crate)`, so that parser cannot move to v3 without a rewrite to embedded-DB introspection. The CLI talks to SurrealDB over HTTP, not the SDK, so it needs no client upgrade.

## Test plan

- [x] `cargo build -p ssp-server -p scheduler -p job-runner` — clean
- [x] `cargo check --locked` (runtime crates) — no lock drift
- [x] `cargo build -p sp00ky-cli` — still builds on v2 core
- [x] `cargo test -p ssp-server --lib` — 11/11 pass
- [x] `cargo test -p scheduler --lib` — 2/2 pass (embedded RocksDB 3.1.2: reset + export/import roundtrip)
- [x] `cargo test -p job-runner` — compiles & runs clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)