### PR TITLE
Batch query-sync notifications and expose a fetching status

### DIFF
--- a/packages/client-solid/src/lib/use-query.ts
+++ b/packages/client-solid/src/lib/use-query.ts
@@ -36,7 +36,12 @@ export function useQuery<
 >(
   finalQuery: QueryArg<S, TableName, T, RelatedFields, IsOne>,
   options?: QueryOptions,
-): { data: () => TData | undefined; error: () => Error | undefined; isLoading: () => boolean };
+): {
+  data: () => TData | undefined;
+  error: () => Error | undefined;
+  isLoading: () => boolean;
+  isFetching: () => boolean;
+};
 
 // Overload: explicit db (backward-compatible)
 export function useQuery<
@@ -50,7 +55,12 @@ export function useQuery<
   db: SyncedDb<S>,
   finalQuery: QueryArg<S, TableName, T, RelatedFields, IsOne>,
   options?: QueryOptions,
-): { data: () => TData | undefined; error: () => Error | undefined; isLoading: () => boolean };
+): {
+  data: () => TData | undefined;
+  error: () => Error | undefined;
+  isLoading: () => boolean;
+  isFetching: () => boolean;
+};
 
 // Implementation
 export function useQuery<
@@ -97,6 +107,7 @@ export function useQuery<
   const [data, setData] = createSignal<TData | undefined>(undefined);
   const [error, setError] = createSignal<Error | undefined>(undefined);
   const [isFetched, setIsFetched] = createSignal(false);
+  const [isFetching, setIsFetching] = createSignal(false);
   const [unsubscribe, setUnsubscribe] = createSignal<(() => void) | undefined>(undefined);
   let prevQueryString: string | undefined;
 
@@ -125,7 +136,18 @@ export function useQuery<
       { immediate: true }
     );
 
-    setUnsubscribe(() => unsub);
+    // Mirror the query's fetch status so the UI can show a "loading more"
+    // state while the sync engine pulls missing records in the background.
+    const unsubStatus = sp00ky.subscribeQueryStatus(
+      hash,
+      (status) => setIsFetching(status === 'fetching'),
+      { immediate: true }
+    );
+
+    setUnsubscribe(() => () => {
+      unsub();
+      unsubStatus();
+    });
   };
 
   createEffect(() => {
@@ -168,5 +190,6 @@ export function useQuery<
     data,
     error,
     isLoading,
+    isFetching,
   };
 }

--- a/packages/core/src/modules/cache/index.ts
+++ b/packages/core/src/modules/cache/index.ts
@@ -119,11 +119,19 @@ export class CacheModule implements StreamUpdateReceiver {
         await this.local.execute(query, params);
       }
 
-      // 2. Batch ingest into DBSP (use populatedRecords which has _00_rv set)
-      for (const record of populatedRecords) {
-        const recordId = encodeRecordId(record.record.id);
-        this.versionLookups[recordId] = record.version;
-        this.streamProcessor.ingest(record.table, record.op, recordId, record.record);
+      // 2. Batch ingest into DBSP (use populatedRecords which has _00_rv set).
+      // Open a coalescing window so the per-record stream updates collapse into
+      // a single notification per affected query — the UI then updates once,
+      // after the whole batch is ingested, instead of row-by-row.
+      this.streamProcessor.beginBatch();
+      try {
+        for (const record of populatedRecords) {
+          const recordId = encodeRecordId(record.record.id);
+          this.versionLookups[recordId] = record.version;
+          this.streamProcessor.ingest(record.table, record.op, recordId, record.record);
+        }
+      } finally {
+        this.streamProcessor.endBatch();
       }
 
       this.logger.debug(

--- a/packages/core/src/modules/data/data.status.test.ts
+++ b/packages/core/src/modules/data/data.status.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { RecordId } from 'surrealdb';
+import { DataModule } from './index';
+import type { QueryState, QueryStatus } from '../../types';
+
+/**
+ * Tests for the per-query fetch status (idle/fetching) added to DataModule:
+ * setQueryStatus updates the query object and notifies both the DevTools
+ * observer hook and subscribeStatus listeners.
+ */
+
+function makeLogger(): any {
+  const noop = () => {};
+  const logger: any = { debug: noop, info: noop, warn: noop, error: noop, trace: noop };
+  logger.child = () => logger;
+  return logger;
+}
+
+function makeDataModule(): DataModule<any> {
+  return new DataModule(
+    {} as any, // cache — unused by status methods
+    {} as any, // local — unused by status methods
+    { tables: [] } as any, // schema — unused by status methods
+    makeLogger(),
+    100
+  );
+}
+
+function makeQueryState(hash: string): QueryState {
+  return {
+    config: {
+      id: new RecordId('_00_query', hash),
+      surql: 'SELECT * FROM user',
+      params: {},
+      localArray: [],
+      remoteArray: [],
+      ttl: '10m',
+      lastActiveAt: new Date(),
+      tableName: 'user',
+    },
+    records: [],
+    ttlTimer: null,
+    ttlDurationMs: 0,
+    updateCount: 0,
+    materializationSamples: [],
+    lastIngestLatencyMs: null,
+    errorCount: 0,
+    status: 'idle',
+  };
+}
+
+describe('DataModule query fetch status', () => {
+  let dm: DataModule<any>;
+  const hash = 'h1';
+
+  beforeEach(() => {
+    dm = makeDataModule();
+    (dm as any).activeQueries.set(hash, makeQueryState(hash));
+  });
+
+  it('subscribeStatus with immediate reports the current status', () => {
+    const seen: QueryStatus[] = [];
+    dm.subscribeStatus(hash, (s) => seen.push(s), { immediate: true });
+    expect(seen).toEqual(['idle']);
+  });
+
+  it('setQueryStatus updates the query object and notifies subscribers + observer', () => {
+    const observed: Array<[string, QueryStatus]> = [];
+    dm.onQueryStatusChange = (h, s) => observed.push([h, s]);
+
+    const seen: QueryStatus[] = [];
+    dm.subscribeStatus(hash, (s) => seen.push(s));
+
+    dm.setQueryStatus(hash, 'fetching');
+    expect((dm as any).activeQueries.get(hash).status).toBe('fetching');
+    expect(seen).toEqual(['fetching']);
+    expect(observed).toEqual([[hash, 'fetching']]);
+
+    dm.setQueryStatus(hash, 'idle');
+    expect(seen).toEqual(['fetching', 'idle']);
+    expect(observed).toEqual([[hash, 'fetching'], [hash, 'idle']]);
+  });
+
+  it('setQueryStatus is a no-op when the status is unchanged', () => {
+    const seen: QueryStatus[] = [];
+    dm.subscribeStatus(hash, (s) => seen.push(s));
+    dm.setQueryStatus(hash, 'idle'); // already idle
+    expect(seen).toEqual([]);
+  });
+
+  it('setQueryStatus is a no-op for an unknown query', () => {
+    let called = false;
+    dm.onQueryStatusChange = () => {
+      called = true;
+    };
+    dm.setQueryStatus('does-not-exist', 'fetching');
+    expect(called).toBe(false);
+  });
+
+  it('unsubscribe stops further status notifications', () => {
+    const seen: QueryStatus[] = [];
+    const unsub = dm.subscribeStatus(hash, (s) => seen.push(s));
+    dm.setQueryStatus(hash, 'fetching');
+    unsub();
+    dm.setQueryStatus(hash, 'idle');
+    expect(seen).toEqual(['fetching']);
+  });
+});

--- a/packages/core/src/modules/data/index.ts
+++ b/packages/core/src/modules/data/index.ts
@@ -14,6 +14,8 @@ import type {
   QueryConfig,
   QueryHash,
   QueryState,
+  QueryStatus,
+  QueryStatusCallback,
   QueryTimeToLive,
   QueryUpdateCallback,
   MutationCallback,
@@ -46,9 +48,17 @@ export class DataModule<S extends SchemaStructure> {
   private activeQueries: Map<QueryHash, QueryState> = new Map();
   private pendingQueries: Map<QueryHash, Promise<QueryHash>> = new Map();
   private subscriptions: Map<QueryHash, Set<QueryUpdateCallback>> = new Map();
+  private statusSubscriptions: Map<QueryHash, Set<QueryStatusCallback>> = new Map();
   private mutationCallbacks: Set<MutationCallback> = new Set();
   private debounceTimers: Map<QueryHash, NodeJS.Timeout> = new Map();
   private logger: Logger;
+  /**
+   * Optional observer notified whenever a query's fetch status changes.
+   * Wired by Sp00kyClient to push status changes into DevTools. Kept as a
+   * settable field (rather than a constructor arg) because DevTools is
+   * constructed after DataModule.
+   */
+  public onQueryStatusChange?: (hash: QueryHash, status: QueryStatus) => void;
   // Salt for query-id hashing. Set from SurrealDB's session::id() so two
   // browser sessions registering the same logical query (same surql + params)
   // don't collide on the same `_00_query` row — each session gets its own.
@@ -192,6 +202,58 @@ export class DataModule<S extends SchemaStructure> {
         }
       }
     };
+  }
+
+  /**
+   * Subscribe to a query's fetch-status changes (idle/fetching).
+   * With `{ immediate: true }` the callback fires synchronously with the
+   * current status (defaults to `idle` if the query isn't registered yet).
+   */
+  subscribeStatus(
+    queryHash: string,
+    callback: QueryStatusCallback,
+    options: { immediate?: boolean } = {}
+  ): () => void {
+    if (!this.statusSubscriptions.has(queryHash)) {
+      this.statusSubscriptions.set(queryHash, new Set());
+    }
+    this.statusSubscriptions.get(queryHash)?.add(callback);
+
+    if (options.immediate) {
+      callback(this.activeQueries.get(queryHash)?.status ?? 'idle');
+    }
+
+    return () => {
+      const subs = this.statusSubscriptions.get(queryHash);
+      if (subs) {
+        subs.delete(callback);
+        if (subs.size === 0) {
+          this.statusSubscriptions.delete(queryHash);
+        }
+      }
+    };
+  }
+
+  /**
+   * Set a query's fetch status and notify status observers (DevTools +
+   * `subscribeStatus` listeners). No-op when the status is unchanged or the
+   * query is unknown.
+   */
+  setQueryStatus(queryHash: string, status: QueryStatus): void {
+    const queryState = this.activeQueries.get(queryHash);
+    if (!queryState || queryState.status === status) {
+      return;
+    }
+    queryState.status = status;
+
+    this.onQueryStatusChange?.(queryHash, status);
+
+    const subs = this.statusSubscriptions.get(queryHash);
+    if (subs) {
+      for (const callback of subs) {
+        callback(status);
+      }
+    }
   }
 
   /**
@@ -954,6 +1016,7 @@ export class DataModule<S extends SchemaStructure> {
       materializationSamples: [],
       lastIngestLatencyMs: null,
       errorCount: persistedErrorCount,
+      status: 'idle',
     };
   }
 

--- a/packages/core/src/modules/devtools/index.ts
+++ b/packages/core/src/modules/devtools/index.ts
@@ -51,6 +51,10 @@ export class DevToolsService implements StreamUpdateReceiver {
       result.set(queryHash, {
         queryHash,
         status: 'active',
+        // Runtime fetch status, distinct from the `status: 'active'`
+        // registration flag above. `fetchStatus` is 'idle' | 'fetching'.
+        fetchStatus: q.status,
+        isFetching: q.status === 'fetching',
         createdAt:
           q.config.lastActiveAt instanceof Date
             ? q.config.lastActiveAt.getTime()

--- a/packages/core/src/modules/sync/sync.ts
+++ b/packages/core/src/modules/sync/sync.ts
@@ -1,5 +1,5 @@
 import type { LocalDatabaseService, RemoteDatabaseService } from '../../services/database/index';
-import type { RecordVersionArray } from '../../types';
+import type { RecordVersionArray, RecordVersionDiff } from '../../types';
 import { createSyncEventSystem, SyncEventTypes, SyncQueueEventTypes } from './events/index';
 import type { Logger } from '../../services/logger/index';
 import type { DownEvent, UpEvent} from './queue/index';
@@ -17,7 +17,7 @@ import { SyncScheduler } from './scheduler';
 import type { SchemaStructure } from '@spooky-sync/query-builder';
 import type { CacheModule } from '../cache/index';
 import type { DataModule } from '../data/index';
-import { encodeRecordId, extractTablePart, surql } from '../../utils/index';
+import { encodeRecordId, extractIdPart, extractTablePart, surql } from '../../utils/index';
 import { DEFAULT_REF_MODE, listRefTableFor, RefMode } from '../ref-tables';
 
 /**
@@ -450,7 +450,10 @@ export class Sp00kySync<S extends SchemaStructure> {
       'Live update is being processed'
     );
     const diff = createDiffFromDbOp(action, recordId, version, localArray);
-    await this.syncEngine.syncRecords(diff);
+    // `config.id` is `_00_query:<hash>`, so its id-part IS the query hash
+    // (a SHA-256 over query content + sessionId) — the key DataModule uses.
+    const hash = extractIdPart(existing.config.id);
+    await this.runSyncForQuery(hash, diff);
   }
 
   /**
@@ -592,7 +595,28 @@ export class Sp00kySync<S extends SchemaStructure> {
     if (!diff) {
       return;
     }
-    return this.syncEngine.syncRecords(diff);
+    return this.runSyncForQuery(hash, diff);
+  }
+
+  /**
+   * Run a sync for a single query while reflecting its fetch status. Marks the
+   * query `fetching` for the duration when the diff actually pulls records
+   * (added/updated), then resets to `idle` in a `finally` so a failed sync
+   * never leaves a query stuck `fetching`. Part A's notification coalescing
+   * means the single resulting UI update lands after this completes.
+   */
+  private async runSyncForQuery(hash: string, diff: RecordVersionDiff): Promise<void> {
+    const fetching = diff.added.length + diff.updated.length > 0;
+    if (fetching) {
+      this.dataModule.setQueryStatus(hash, 'fetching');
+    }
+    try {
+      await this.syncEngine.syncRecords(diff);
+    } finally {
+      if (fetching) {
+        this.dataModule.setQueryStatus(hash, 'idle');
+      }
+    }
   }
 
   /**

--- a/packages/core/src/services/stream-processor/index.ts
+++ b/packages/core/src/services/stream-processor/index.ts
@@ -53,6 +53,12 @@ export class StreamProcessorService {
   private processor: WasmProcessor | undefined;
   private isInitialized = false;
   private receivers: StreamUpdateReceiver[] = [];
+  // When true, `notifyUpdates` coalesces updates into `batchBuffer` (keyed by
+  // queryHash) instead of dispatching them. Used to collapse the per-record
+  // stream updates produced by a batched ingest into a single notification per
+  // query, so the UI updates once after the whole batch rather than row-by-row.
+  private batching = false;
+  private batchBuffer: Map<string, StreamUpdate> = new Map();
 
   constructor(
     public events: EventSystem<StreamProcessorEvents>,
@@ -72,11 +78,68 @@ export class StreamProcessorService {
   }
 
   private notifyUpdates(updates: StreamUpdate[]) {
+    if (this.batching) {
+      // Coalesce by queryHash instead of dispatching. The WASM `result_data`
+      // (localArray) is the full materialized array, so last-write-wins
+      // already reflects every prior ingest in the batch. We sum the
+      // materialization times so the single recorded sample reflects the
+      // batch's total work, and emit `op: 'CREATE'` on flush so the coalesced
+      // update takes DataModule's immediate (non-debounced) path.
+      for (const update of updates) {
+        const prev = this.batchBuffer.get(update.queryHash);
+        const summedTime =
+          (prev?.materializationTimeMs ?? 0) + (update.materializationTimeMs ?? 0);
+        this.batchBuffer.set(update.queryHash, {
+          ...update,
+          op: 'CREATE',
+          materializationTimeMs: summedTime,
+        });
+      }
+      return;
+    }
+
+    this.dispatchUpdates(updates);
+  }
+
+  private dispatchUpdates(updates: StreamUpdate[]) {
     for (const update of updates) {
       for (const receiver of this.receivers) {
         receiver.onStreamUpdate(update);
       }
     }
+  }
+
+  /**
+   * Open a coalescing window. While open, the per-record stream updates
+   * emitted by `ingest` are buffered (one entry per queryHash) instead of
+   * dispatched. Pair with `endBatch()` in a try/finally so the window always
+   * closes — otherwise the processor stays stuck buffering forever.
+   *
+   * No-op if a batch is already open (nested batches aren't expected here).
+   */
+  beginBatch() {
+    if (this.batching) return;
+    this.batching = true;
+    this.batchBuffer.clear();
+  }
+
+  /**
+   * Close the coalescing window and flush: dispatch one coalesced
+   * `StreamUpdate` per buffered queryHash, then persist processor state once
+   * for the whole batch (instead of once per ingest).
+   */
+  endBatch() {
+    if (!this.batching) return;
+    this.batching = false;
+    const buffered = Array.from(this.batchBuffer.values());
+    this.batchBuffer.clear();
+    if (buffered.length > 0) {
+      this.dispatchUpdates(buffered);
+    }
+    // The processor state after the last ingest is cumulative, so a single
+    // snapshot covers the whole batch. Kept fire-and-forget like the per-ingest
+    // call it replaces.
+    this.saveState();
   }
 
   /**
@@ -236,7 +299,11 @@ export class StreamProcessorService {
         // Direct handler call instead of event
         this.notifyUpdates(updates);
       }
-      this.saveState();
+      // While batching, `endBatch` persists once for the whole batch — skip the
+      // redundant per-record snapshot here.
+      if (!this.batching) {
+        this.saveState();
+      }
       return rawUpdates;
     } catch (e) {
       this.logger.error(

--- a/packages/core/src/services/stream-processor/stream-processor.batch.test.ts
+++ b/packages/core/src/services/stream-processor/stream-processor.batch.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { StreamProcessorService } from './index';
+import type { StreamUpdate, StreamUpdateReceiver } from './index';
+import type { WasmProcessor, WasmStreamUpdate } from './wasm-types';
+
+/**
+ * Tests for the batch-coalescing window added to StreamProcessorService.
+ *
+ * A batched ingest (e.g. sync fetching N missing records) used to emit one
+ * stream update per record, making the UI render row-by-row. beginBatch/
+ * endBatch collapse those into a single coalesced update per affected query.
+ */
+
+function makeLogger(): any {
+  const noop = () => {};
+  const logger: any = {
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop,
+    trace: noop,
+  };
+  logger.child = () => logger;
+  return logger;
+}
+
+/** Records every dispatched update so we can count notifications. */
+class RecordingReceiver implements StreamUpdateReceiver {
+  public received: StreamUpdate[] = [];
+  onStreamUpdate(update: StreamUpdate): void {
+    this.received.push(update);
+  }
+}
+
+/**
+ * Build a service with a stubbed WASM processor. The processor accumulates
+ * ingested ids and returns the *full* materialized array on every call (as the
+ * real WASM does), so coalescing's last-write-wins must yield the final array.
+ */
+function makeService(queryHashesFor: (id: string) => string[]) {
+  const svc = new StreamProcessorService(
+    {} as any,
+    {} as any,
+    { get: async () => undefined, set: async () => {} } as any,
+    makeLogger()
+  );
+
+  const ingestedByQuery = new Map<string, Array<[string, number]>>();
+  const mockProcessor: Partial<WasmProcessor> = {
+    ingest: (_table, _op, id, record: any): WasmStreamUpdate[] => {
+      const version = record?._00_rv ?? 1;
+      const updates: WasmStreamUpdate[] = [];
+      for (const queryHash of queryHashesFor(id)) {
+        const arr = ingestedByQuery.get(queryHash) ?? [];
+        arr.push([id, version]);
+        ingestedByQuery.set(queryHash, arr);
+        updates.push({ query_id: queryHash, result_data: [...arr] });
+      }
+      return updates;
+    },
+  };
+  // processor is private and normally set by init() via WASM; inject the stub.
+  (svc as any).processor = mockProcessor;
+  return svc;
+}
+
+describe('StreamProcessor batch coalescing', () => {
+  let receiver: RecordingReceiver;
+
+  beforeEach(() => {
+    receiver = new RecordingReceiver();
+  });
+
+  it('emits one update per record when NOT batching (baseline)', () => {
+    const svc = makeService(() => ['q1']);
+    svc.addReceiver(receiver);
+
+    svc.ingest('user', 'CREATE', 'user:1', { id: 'user:1', _00_rv: 1 });
+    svc.ingest('user', 'CREATE', 'user:2', { id: 'user:2', _00_rv: 1 });
+    svc.ingest('user', 'CREATE', 'user:3', { id: 'user:3', _00_rv: 1 });
+
+    expect(receiver.received).toHaveLength(3);
+  });
+
+  it('coalesces a batch into a single update per query with the final array', () => {
+    const svc = makeService(() => ['q1']);
+    svc.addReceiver(receiver);
+
+    svc.beginBatch();
+    try {
+      svc.ingest('user', 'CREATE', 'user:1', { id: 'user:1', _00_rv: 1 });
+      svc.ingest('user', 'CREATE', 'user:2', { id: 'user:2', _00_rv: 1 });
+      svc.ingest('user', 'CREATE', 'user:3', { id: 'user:3', _00_rv: 1 });
+    } finally {
+      svc.endBatch();
+    }
+
+    // Nothing dispatched until endBatch, then exactly one coalesced update.
+    expect(receiver.received).toHaveLength(1);
+    const update = receiver.received[0];
+    expect(update.queryHash).toBe('q1');
+    // Last-write-wins carries the full materialized array (all 3 records).
+    expect(update.localArray).toHaveLength(3);
+    // Coalesced updates take DataModule's immediate (non-debounced) path.
+    expect(update.op).toBe('CREATE');
+    expect(typeof update.materializationTimeMs).toBe('number');
+  });
+
+  it('coalesces independently per affected query', () => {
+    // user:1 -> q1, user:2 -> q1 & q2, user:3 -> q2
+    const svc = makeService((id) =>
+      id === 'user:1' ? ['q1'] : id === 'user:2' ? ['q1', 'q2'] : ['q2']
+    );
+    svc.addReceiver(receiver);
+
+    svc.beginBatch();
+    try {
+      svc.ingest('user', 'CREATE', 'user:1', { id: 'user:1', _00_rv: 1 });
+      svc.ingest('user', 'CREATE', 'user:2', { id: 'user:2', _00_rv: 1 });
+      svc.ingest('user', 'CREATE', 'user:3', { id: 'user:3', _00_rv: 1 });
+    } finally {
+      svc.endBatch();
+    }
+
+    expect(receiver.received).toHaveLength(2);
+    const byHash = Object.fromEntries(receiver.received.map((u) => [u.queryHash, u]));
+    expect(Object.keys(byHash).sort()).toEqual(['q1', 'q2']);
+  });
+
+  it('endBatch is safe with no buffered updates, and beginBatch is idempotent', () => {
+    const svc = makeService(() => ['q1']);
+    svc.addReceiver(receiver);
+
+    svc.beginBatch();
+    svc.beginBatch(); // no-op, must not reset/duplicate
+    svc.endBatch();
+
+    expect(receiver.received).toHaveLength(0);
+    // A subsequent non-batched ingest dispatches normally (window fully closed).
+    svc.ingest('user', 'CREATE', 'user:1', { id: 'user:1', _00_rv: 1 });
+    expect(receiver.received).toHaveLength(1);
+  });
+});

--- a/packages/core/src/sp00ky.ts
+++ b/packages/core/src/sp00ky.ts
@@ -2,6 +2,7 @@ import { DataModule } from './modules/data/index';
 import type {
   Sp00kyConfig,
   QueryTimeToLive,
+  QueryStatusCallback,
   Sp00kyQueryResultPromise,
   PersistenceClient,
   UpdateOptions,
@@ -221,6 +222,13 @@ export class Sp00kyClient<S extends SchemaStructure> {
    * Setup direct callbacks instead of event subscriptions
    */
   private setupCallbacks() {
+    // Surface query fetch-status changes (idle/fetching) in DevTools. Logs a
+    // discrete event and triggers a state push so the active-queries panel
+    // reflects the flip immediately.
+    this.dataModule.onQueryStatusChange = (queryHash, status) => {
+      this.devTools.logEvent('QUERY_STATUS_CHANGED', { queryHash, status });
+    };
+
     // Mutation callback for sync
     this.dataModule.onMutation((mutations: UpEvent[]) => {
       // Notify DevTools
@@ -452,6 +460,19 @@ export class Sp00kyClient<S extends SchemaStructure> {
     options?: { immediate?: boolean }
   ): Promise<() => void> {
     return this.dataModule.subscribe(queryHash, callback, options);
+  }
+
+  /**
+   * Subscribe to a query's fetch-status changes (idle/fetching). With
+   * `{ immediate: true }` the callback fires synchronously with the current
+   * status. Powers the `useQuery` hook's `isFetching()` accessor.
+   */
+  subscribeQueryStatus(
+    queryHash: string,
+    callback: QueryStatusCallback,
+    options?: { immediate?: boolean }
+  ): () => void {
+    return this.dataModule.subscribeStatus(queryHash, callback, options);
   }
 
   run<

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -179,6 +179,15 @@ export interface QueryConfig {
 export type QueryConfigRecord = QueryConfig & { id: string };
 
 /**
+ * Runtime fetch status of a live query.
+ * - `idle`: not currently fetching missing records.
+ * - `fetching`: the sync engine is fetching/ingesting missing records for this
+ *   query. UI notifications are coalesced so the result lands as a single
+ *   update once fetching completes.
+ */
+export type QueryStatus = 'idle' | 'fetching';
+
+/**
  * Internal state of a live query.
  */
 export interface QueryState {
@@ -202,6 +211,12 @@ export interface QueryState {
   lastIngestLatencyMs: number | null;
   /** Cumulative count of ingest/materialization errors observed for this query. */
   errorCount: number;
+  /**
+   * Ephemeral runtime fetch status. Not persisted to `_00_query`; observable
+   * via DevTools and the `useQuery` hook. `fetching` while the sync engine is
+   * pulling missing records for this query, otherwise `idle`.
+   */
+  status: QueryStatus;
 }
 
 /** Cap on the rolling materialization-sample window kept per query in memory. */
@@ -209,6 +224,7 @@ export const MATERIALIZATION_SAMPLE_WINDOW = 100;
 
 // Callback types
 export type QueryUpdateCallback = (records: Record<string, any>[]) => void;
+export type QueryStatusCallback = (status: QueryStatus) => void;
 export type MutationCallback = (mutations: UpEvent[]) => void;
 
 export type MutationEventType = 'create' | 'update' | 'delete';


### PR DESCRIPTION
## Problem

When a query gained records not yet cached locally, the sync engine fetched them in one batch but ingested them into DBSP one at a time, emitting a stream update per record. CREATE updates aren't debounced, so each record fired its own UI notification, and lists rendered row-by-row.

## Changes

**Coalesce per-query updates into a single notification:**
- Add a `begin`/`endBatch` coalescing window to `StreamProcessorService`. While open, `notifyUpdates` buffers updates by `queryHash` (last-write-wins on the full materialized array, summed materialization time, flushed as CREATE for immediate processing) instead of dispatching. `saveState` runs once per batch instead of per record.
- Wrap the ingest loop in `CacheModule.saveBatch` with the window, so the UI updates once after the whole batch is ingested.

**Expose a per-query fetch status:**
- Add `QueryStatus` (`'idle' | 'fetching'`) to `QueryState`, a `setQueryStatus` method and `subscribeStatus` channel on `DataModule`, and an `onQueryStatusChange` observer wired to DevTools.
- `Sp00kySync` flips a query to `'fetching'` around `syncRecords` (both call sites, reset in `finally`) via a shared `runSyncForQuery` helper.
- Surface `fetchStatus`/`isFetching` in DevTools active-query state and expose `isFetching()` from the `useQuery` Solid hook.

## Tests

Adds coverage for the coalescing window (`stream-processor.batch.test.ts`) and the status channel (`data.status.test.ts`).

> Restored from a git bundle and pushed for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)